### PR TITLE
DASHBOARD - Set dashboard, navbar and bootstrap offcanvas

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @import "config/colors";
 @import "config/bootstrap_variables";
 
+
 // External libraries
 @import "bootstrap/scss/bootstrap";
 @import "font-awesome";
@@ -10,3 +11,6 @@
 // Your CSS partials
 @import "components/index";
 @import "pages/index";
+
+// To override default styles and default Bootstrap ones
+@import "config/global";

--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -1,10 +1,14 @@
 .avatar {
   width: 40px;
+  height: 40px;
   border-radius: 50%;
 }
+
 .avatar-large {
-  width: 56px;
+  width: 60px;
+  height: 60px;
   border-radius: 50%;
+  background: blue;
 }
 .avatar-bordered {
   width: 40px;

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -3,3 +3,4 @@
 @import "avatar";
 @import "form_legend_clear";
 @import "navbar";
+@import "offcanvas";

--- a/app/assets/stylesheets/components/_lewagon_navbar.scss
+++ b/app/assets/stylesheets/components/_lewagon_navbar.scss
@@ -1,0 +1,12 @@
+.navbar-lewagon {
+  justify-content: space-between;
+  background: white;
+}
+
+.navbar-lewagon .navbar-collapse {
+  flex-grow: 0;
+}
+
+.navbar-lewagon .navbar-brand img {
+  width: 40px;
+}

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,12 +1,48 @@
-.navbar-lewagon {
+.navbar {
+  padding: 5px 30px;
+  display: flex;
   justify-content: space-between;
-  background: white;
+  align-items: center;
+  border-bottom: 0.2px solid black;
+
+  .logo {
+    font-weight: bold;
+    margin-bottom: 0;
+  }
+
+  .avatar{
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    background: grey;
+  }
+
+  .nav li a {
+    display: inline;
+    font-size: 18px;
+    padding: 10px;
+    width: 100%;
+    &:hover {
+      background:rgb(193, 193, 193);
+      cursor: pointer;
+    }
+  }
+
 }
 
-.navbar-lewagon .navbar-collapse {
-  flex-grow: 0;
+.menu {
+  font-size: 30px;
+  display: none;
+  text-decoration: none;
+  color: black;
 }
 
-.navbar-lewagon .navbar-brand img {
-  width: 40px;
+@media(max-width: 768px) {
+  .menu {
+    display: block;
+  }
+
+  .nav {
+    display: none;
+  }
 }

--- a/app/assets/stylesheets/components/_offcanvas.scss
+++ b/app/assets/stylesheets/components/_offcanvas.scss
@@ -1,0 +1,39 @@
+.offcanvas {
+  max-width: 95%;
+}
+
+.offcanvas-body {
+  padding: 50px 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  .offcanvas-nav {
+    margin-top: 20px;
+    padding: 0;
+    li a {
+      display: block;
+      padding: 10px 30px;
+      font-size: 18px;
+      font-weight: bold;
+      &:hover {
+        background: rgb(193, 193, 193);
+        cursor: pointer;
+      }
+    }
+  }
+
+  .actions {
+    li {
+      font-size: 18px;
+      font-weight: bold;
+      display: block;
+      padding: 10px 30px;
+    }
+
+    i {
+      font-size: 30px;
+      margin-right: 10px;
+    }
+  }
+}

--- a/app/assets/stylesheets/config/_global.scss
+++ b/app/assets/stylesheets/config/_global.scss
@@ -1,0 +1,13 @@
+a {
+  color: black;
+  text-decoration: none;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+li {
+  display: inline;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,14 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    
   </head>
 
-  <body><%= render "shared/navbar" %>
-<%= render "shared/flashes" %>
+  <body>
+    <%= render "shared/navbar" %>
+    <%= render "shared/flashes" %>
 
-    <%= yield %>
+    <div class="content">
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,2 +1,42 @@
-<h1>Pages#home</h1>
-<p>Find me in app/views/pages/home.html.erb</p>
+<div class="container">
+  <h1>Welcome back, M</h1>
+  <p>Chairman of Shioya Street</p>
+
+  <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.
+  Debitis fugit ipsa tempore natus, placeat quae minus nihil sunt cum,
+  animi culpa corporis adipisci
+  quidem similique quam laudantium voluptate alias? In?</p>
+
+  <%# Stadisticst for chairman %>
+  <div class="stadistics"></div>
+
+  <%# Stamp rallies list %>
+  <div class="stamprallies"></div>
+
+  <%# Latest added shops %>
+  <div class="div">
+    <div class="d-flex align-items-center">
+      <h3>Last added shops</h3>
+      <%= link_to "See all shops", "#"%>
+    </div>
+    <div class="grid">
+      <div class="shop">
+        <p>Shop name</p>
+        <p>Shop address</p>
+      </div>
+      <div class="shop">
+        <p>Shop name</p>
+        <p>Shop address</p>
+      </div>
+      <div class="shop">
+        <p>Shop name</p>
+        <p>Shop address</p>
+      </div>
+      <div class="shop">
+        <p>Shop name</p>
+        <p>Shop address</p>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/app/views/shared/_lewagon_navbar.html.erb
+++ b/app/views/shared/_lewagon_navbar.html.erb
@@ -1,0 +1,36 @@
+<div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
+  <div class="container-fluid">
+    <%= link_to "#", class: "navbar-brand" do %>
+      <%= image_tag "https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/logo.png" %>
+    <% end %>
+
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav me-auto">
+        <% if user_signed_in? %>
+          <li class="nav-item active">
+            <%= link_to "Home", "#", class: "nav-link" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "Messages", "#", class: "nav-link" %>
+          </li>
+          <li class="nav-item dropdown">
+            <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+            <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+              <%= link_to "Action", "#", class: "dropdown-item" %>
+              <%= link_to "Another action", "#", class: "dropdown-item" %>
+              <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %>
+            </div>
+          </li>
+        <% else %>
+          <li class="nav-item">
+            <%= link_to "Login", new_user_session_path, class: "nav-link" %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,36 +1,17 @@
-<div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
-  <div class="container-fluid">
-    <%= link_to "#", class: "navbar-brand" do %>
-      <%= image_tag "https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/logo.png" %>
-    <% end %>
-
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav me-auto">
-        <% if user_signed_in? %>
-          <li class="nav-item active">
-            <%= link_to "Home", "#", class: "nav-link" %>
-          </li>
-          <li class="nav-item">
-            <%= link_to "Messages", "#", class: "nav-link" %>
-          </li>
-          <li class="nav-item dropdown">
-            <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
-            <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
-              <%= link_to "Action", "#", class: "dropdown-item" %>
-              <%= link_to "Another action", "#", class: "dropdown-item" %>
-              <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %>
-            </div>
-          </li>
-        <% else %>
-          <li class="nav-item">
-            <%= link_to "Login", new_user_session_path, class: "nav-link" %>
-          </li>
-        <% end %>
-      </ul>
-    </div>
+<div class="navbar">
+  <div class="logo">
+    <h5 class="logo">SAMPOMPOM</h5>
   </div>
+
+  <ul class="nav">
+    <li><%= link_to "Dashboard", root_path %></li>
+    <li><%= link_to "Shops", "#" %></li>
+    <li><%= link_to "Rallies", "#" %></li>
+  </ul>
+
+  <div class="d-flex align-items-center">
+    <%= render 'shared/offcanvas'%>
+    <div class="avatar ms-5"></div>
+  </div>
+
 </div>

--- a/app/views/shared/_offcanvas.html.erb
+++ b/app/views/shared/_offcanvas.html.erb
@@ -1,0 +1,25 @@
+<a class="menu" data-bs-toggle="offcanvas" href="#offcanvasExample" role="button" aria-controls="offcanvasExample">
+  <i class="fa fa-solid fa fa-bars menu" type="button" data-bs-toggle="dropdown" aria-expanded="false"></i>
+</a>
+
+
+<div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasExample" aria-labelledby="offcanvasExampleLabel">
+  <div class="offcanvas-header">
+    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+  </div>
+  <div class="offcanvas-body">
+
+    <div class="avatar-large ms-5"></div>
+
+    <ul class="offcanvas-nav">
+      <li><%= link_to "DASHBOARD", root_path %></li>
+      <li><%= link_to "SHOPS", "#" %></li>
+      <li><%= link_to "RALLIES", "#" %></li>
+    </ul>
+
+    <ul class="actions">
+      <li><i class="fa fa-solid fa fa-sliders"></i> Settings</li>
+      <li>Logout</li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
Changes: 
- Replaced the default LeWagon navbar for SAMPOMPOM navbar
- Added offcanvas Bootstrap module
- The hamburger menu icon only shows on screens smaller than 768px 
- Created global.scss to override default css and default bootstrap ugly styles

<img width="1182" alt="Captura de Pantalla 2023-02-11 a las 12 47 32" src="https://user-images.githubusercontent.com/70474104/218237491-de83eef9-a15c-48c0-9e2a-dbe5d8dd1c6f.png">

<img width="664" alt="Captura de Pantalla 2023-02-11 a las 12 47 23" src="https://user-images.githubusercontent.com/70474104/218237485-954f5d71-b977-4206-8937-d2d7d02c2353.png">
