### PR TITLE
【Structure】Set the dashboard basic structure, made it responsible and added some…

### DIFF
--- a/app/assets/stylesheets/components/_card-shop.scss
+++ b/app/assets/stylesheets/components/_card-shop.scss
@@ -1,17 +1,37 @@
+// STYLES FOR SHOPS DISPLAYED IN THE DASHBOARD
 
-// INDIVIDUAL SHOP CARD
-.shop-card {
-  padding: 10px;
-  box-shadow: 0 0 15px rgba(0,0,0,0.2);
-  border-radius: 3px;
-
-  img {
-    max-height: 130px;
-    border-radius: 5px;
+// 1. Container
+.shops-list {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 10px;
+  @media(max-width: 768px) {
+    grid-template-columns: 1fr;
   }
 }
 
-// SHOPS CONTAINER
+// 2. Individual shop card
+.shop-card-small {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px;
+  box-shadow: 0 0 15px rgba(0,0,0,0.2);
+  border-radius: 5px;
+  .img-container {
+    width: 60px;
+    height: 60px;
+    background: blue;
+    border-radius: 5px;
+    margin-right: 10px;
+  }
+}
+
+
+// STYLES FOR SHOPS DISPLAYED IN INDEX PAGE
+
+// 1. Container
 .shops-container {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -24,5 +44,17 @@
   }
   @media(max-width: 768px) {
     grid-template-columns: 1fr;
+  }
+}
+
+// 2. Individual shop card
+.shop-card {
+  padding: 10px;
+  box-shadow: 0 0 15px rgba(0,0,0,0.2);
+  border-radius: 3px;
+
+  img {
+    max-height: 130px;
+    border-radius: 5px;
   }
 }

--- a/app/assets/stylesheets/components/_card_stamp_rally.scss
+++ b/app/assets/stylesheets/components/_card_stamp_rally.scss
@@ -1,0 +1,29 @@
+
+// STYLES FOR STAMP RALLIES CARDS DISPLAYED IN THE DASHBOARD
+
+// 1. Rallyes container
+.rallies-container {
+  margin-top: 20px;
+}
+
+// 2. Individual stamp rally card
+.rally-card {
+  padding: 10px;
+  background: grey;
+  margin-bottom: 10px;
+  box-shadow: 0 0 15px rgba(0,0,0,0.2);
+  border-radius: 5px;
+  &:hover {
+    color: #000;
+    background: rgb(109, 109, 109);
+  }
+}
+
+.finished {
+  background: rgb(52, 52, 52);
+  color: #fff;
+  &:hover {
+    color: #fff;
+    background: rgb(39, 39, 39);
+  }
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -6,3 +6,4 @@
 @import "offcanvas";
 @import "card-shop";
 @import "map";
+@import "card_stamp_rally"

--- a/app/assets/stylesheets/config/_structure.scss
+++ b/app/assets/stylesheets/config/_structure.scss
@@ -40,6 +40,7 @@ body {
   .content {
     border-radius: 0px;
     margin: 0;
+    height: 100%;
   }
 
   .view-container {
@@ -48,5 +49,6 @@ body {
 
   .scroll-content {
     height: 100%;
+    margin-bottom: 30px;
   }
 }

--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -1,0 +1,19 @@
+.dashboard {
+
+  .dash-content {
+    display: flex;
+    justify-content: space-between;
+    .dash-main {
+      width: 50%;
+    }
+    .dash-rallies {
+      width: 40%;
+    }
+    @media(max-width: 992px) {
+      flex-direction: column-reverse;
+      .dash-main, .dash-rallies {
+        width: 100%;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -1,2 +1,3 @@
 // Import page-specific CSS files here.
 @import "home";
+@import "dashboard";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
-    
+
   </head>
 
   <body>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -1,29 +1,85 @@
-<div class="container">
-  <h1>Welcome back, M</h1>
-  <p>Chairman of Shioya Street</p>
+<div class="container my-5 dashboard">
 
-  <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.
-  Debitis fugit ipsa tempore natus, placeat quae minus nihil sunt cum,
-  animi culpa corporis adipisci
-  quidem similique quam laudantium voluptate alias? In?</p>
-
-  <%# Stadisticst for chairman %>
-  <div class="stadistics"></div>
-
-  <%# Stamp rallies list %>
-  <div class="stamprallies"></div>
-
-  <%# Latest added shops %>
-  <div class="d-flex align-items-center">
-    <h2>Your latest added shops</h2>
-    <%= link_to "See all shops", shops_path %>
+  <div class="dash-user mb-3">
+    <h1>Welcome back, M</h1>
+    <p>Chairman of Shioya Street</p>
   </div>
-  <div class="shops-container">
-    <% @shops.each do |shop| %>
-      <div class="shop-card">
-        <h4><%= shop.name %></h4>
+
+  <div class="dash-content">
+    <div class="dash-main">
+      <%# Stadisticst for chairman %>
+      <div class="stadistics"></div>
+
+      <%# Latest added shops %>
+      <div class="d-flex align-items-center justify-content-between">
+        <h4>Latest added shops</h4>
+        <%= link_to "See all shops", shops_path, class: "btn btn-primary" %>
       </div>
-    <% end %>
-  </div>
+      <div class="shops-list">
+        <% @shops.each do |shop| %>
+          <%= link_to shop_path(shop) do %>
+            <div class="shop-card-small">
+              <div class="img-container">
+                <%# <img src="" alt=""> %>
+              </div>
+              <div class="shop-content p-1">
+                <p><%= shop.name %></p>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
 
+
+    <%# ***** NOTES ***** %>
+    <%# We need to update this code when we have
+    real stamp rallies in the DB!!!
+      - Show real data for each stamp rally with .each
+      - Update the link for each card so it goes to that specific stamp rally show page
+      - DATES LOGIC: if the stamp rally end date is before the current date,
+        we need to add the class "finished" to the card, next to rally-card.
+        No need to code the styles, they can be found in _card_stamp_rally.scss file
+    %>
+
+    <div class="dash-rallies">
+      <div class="d-flex align-items-center justify-content-between">
+        <h4>Stamp rallies</h4>
+        <p><%= link_to "See all", "#", class: "btn btn-primary"%></p>
+      </div>
+
+      <div class="rallies-container">
+
+        <%= link_to "#" do %>
+          <div class="rally-card">
+            <h5>Some content about rally</h5>
+            <p>Start date - End date</p>
+          </div>
+        <% end %>
+
+        <%= link_to "#" do %>
+          <div class="rally-card">
+            <h5>Some content about rally</h5>
+            <p>Start date - End date</p>
+          </div>
+        <% end %>
+
+        <%= link_to "#" do %>
+          <div class="rally-card finished">
+            <h5>Some content about rally</h5>
+            <p>Start date - End date</p>
+          </div>
+        <% end %>
+
+        <%= link_to "#" do %>
+          <div class="rally-card finished">
+            <h5>Some content about rally</h5>
+            <p>Start date - End date</p>
+          </div>
+        <% end %>
+
+
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
Changes: 
- Set the basic structure for the dashboard view: it now shows the 4 newest added shops and the stamp rallies.
- Added two new card components: shop cards and stamp rally cards. These are **specific for the dashboard** and they are **smaller** than the regular ones. 
- Since we don't have any stamp rallies in the DB, I couldn't add any proper information to those cards, so we will need to update this! 🌱 I added some comments in dashboard.html.erb with some guides and ideas, please check them! 

(wide screens)
<img width="1435" alt="Captura de Pantalla 2023-02-12 a las 15 39 39" src="https://user-images.githubusercontent.com/70474104/218296946-59f11044-9a31-448c-9006-d3144a48ab3c.png">

(smaller screens)
<img width="614" alt="Captura de Pantalla 2023-02-12 a las 15 43 51" src="https://user-images.githubusercontent.com/70474104/218297062-aade96d6-1473-4b5e-88aa-f0fe71ded176.png">