### PR TITLE
Add dropdown to navbar, logic for login and logout links

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -1,6 +1,6 @@
 .avatar {
-  width: 40px;
-  height: 40px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
 }
 

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,5 +1,5 @@
 .navbar {
-  padding: 5px 30px;
+  padding: 20px 30px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -8,6 +8,7 @@
   .logo {
     font-weight: bold;
     margin-bottom: 0;
+    padding: 10px 0px;
   }
 
   .avatar{
@@ -45,4 +46,12 @@
   .nav {
     display: none;
   }
+
+  .navbar-avatar {
+    display: none;
+  }
+}
+
+.navbar-collapse {
+  flex-grow: 0;
 }

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,12 +10,24 @@
   </ul>
 
   <div class="d-flex align-items-center">
-    <%= render 'shared/offcanvas'%>
     <% if user_signed_in? %>
-      <div class="avatar ms-5"></div>
+      <div class="ms-5 nav-item dropdown navbar-avatar">
+        <div class="avatar ms-5 dropdown-toggle" id="navbarDropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></div>
+        <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+          <%= link_to "Settings", "#", class: "dropdown-item" %>
+          <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %>
+        </div>
+      </div>
     <% else %>
-      <%= link_to "Login", new_user_session_path %>
+      <%= link_to "Login", new_user_session_path, class: "me-4" %>
     <% end %>
+    <%= render 'shared/offcanvas'%>
   </div>
-
 </div>
+
+<%# ***** NOTE ***** %>
+<%# If current_user.photo.attached? ->
+cl_image_tag(current_user.photo.key, { class: "avatar dropdown-toggle", id: "navbarDropdown", "data-bs-toggle": "dropdown", "aria-haspopup": "true", "aria-expanded": "false" })
+
+if not, display another image:
+image_tag('person_02.jpg', class: "avatar dropdown-toggle", id: "navbarDropdown", "data-bs-toggle": "dropdown", "aria-haspopup": "true", "aria-expanded": "false") %>

--- a/app/views/shared/_offcanvas.html.erb
+++ b/app/views/shared/_offcanvas.html.erb
@@ -18,8 +18,10 @@
     </ul>
 
     <ul class="actions">
-      <li><i class="fa fa-solid fa fa-sliders"></i> Settings</li>
-      <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete} %>
+      <% if user_signed_in? %>
+        <li><i class="fa fa-solid fa fa-sliders"></i> Settings</li>
+        <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete} %>
+      <% end %>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Changes: 
- Added dropdown on the avatar to access settings and logout links on wider screens
- Settings and logout links are only visible if the user is logged in
- The user photo is not displayed in the navbar on smaller screens
- 🌱 I also left some comments in _navbar.html.erb file about adding user photos and check if the user has photos attached or not so we don't get any errors this time (hopefully 🤞)

Smaller screens: the user photo is not displayed
<img width="595" alt="Captura de Pantalla 2023-02-12 a las 16 23 12" src="https://user-images.githubusercontent.com/70474104/218298383-30fa5025-11b0-4015-9c87-a174c80dcfae.png">

Wider screens: the user photo is there, but has a weird black thing and I don't know what is is 🫠
<img width="1050" alt="Captura de Pantalla 2023-02-12 a las 16 23 47" src="https://user-images.githubusercontent.com/70474104/218298404-a7304fa4-0a39-4d0d-9574-e963b3193f84.png">

Dropdown on wider screens
<img width="1046" alt="Captura de Pantalla 2023-02-12 a las 16 24 28" src="https://user-images.githubusercontent.com/70474104/218298428-0c81efaf-970e-41cf-b841-d8394e891c71.png">

