### PR TITLE
implemented PDF generating function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,3 +83,5 @@ gem "pundit"
 gem "geocoder"
 gem 'rqrcode'
 gem "cloudinary"
+gem 'wkhtmltopdf-binary'
+gem 'wicked_pdf'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,6 +275,9 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    wicked_pdf (2.6.3)
+      activesupport
+    wkhtmltopdf-binary (0.12.6.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.6)
@@ -312,6 +315,8 @@ DEPENDENCIES
   tzinfo-data
   web-console
   webdrivers
+  wicked_pdf
+  wkhtmltopdf-binary
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/controllers/shop_participants_controller.rb
+++ b/app/controllers/shop_participants_controller.rb
@@ -6,7 +6,12 @@ class ShopParticipantsController < ApplicationController
   end
 
   def stamped
-    @stamp_card = StampCard.find(params[:id])
-    @stamped = @stamp_card.shop_participant.status = "stamped"
+    # @participant = Paticipant.find(params[:participant_id])
+    @stamp_card = StampCard.find(params[:stamp_card_id])
+    @shop_participant = ShopParticipant.find(params[:id])
+    @stamp_card.shop_participant = @shop_participant
+    authorize @shop_participant
+    @shop_participant.stamped!
+    redirect_to stamp_card_path(@stamp_card)
   end
 end

--- a/app/controllers/stamp_cards_controller.rb
+++ b/app/controllers/stamp_cards_controller.rb
@@ -1,5 +1,5 @@
 class StampCardsController < ApplicationController
-  before_action :set_shop_participant, only: %i[show new create]
+  before_action :set_shop_participant, only: %i[show new create print]
 
   def show
     @stamp_card = StampCard.find(params[:id])
@@ -38,6 +38,30 @@ class StampCardsController < ApplicationController
     # else
     #   render :new, status: :unprocessable_entity
     # end
+  end
+
+  def print
+    @stamp_card = StampCard.find(params[:id])
+    @stamp_card.shop_participant = @shop_participant
+    @qr_code = RQRCode::QRCode.new(@stamp_card.qr_code)
+    @svg = @qr_code.as_svg(
+      offset: 0,
+      color: '000',
+      shape_rendering: 'crispEdges',
+      standalone: true,
+      module_size: 10
+    )
+    authorize @stamp_card
+
+    respond_to do |format|
+      format.html
+      format.pdf do
+        render pdf: "#{@shop_participant.shop.name}",
+               layout: 'application',
+               encording: 'UTF-8',
+               show_as_html: params[:debug].present?
+      end
+    end
   end
 
   private

--- a/app/policies/shop_participant_policy.rb
+++ b/app/policies/shop_participant_policy.rb
@@ -21,4 +21,9 @@ class ShopParticipantPolicy < ApplicationPolicy
   def new?
     create?
   end
+
+  def stamped?
+    true
+    # record.stamp_card.participant == user
+  end
 end

--- a/app/policies/stamp_card_policy.rb
+++ b/app/policies/stamp_card_policy.rb
@@ -21,4 +21,8 @@ class StampCardPolicy < ApplicationPolicy
   def new?
     create?
   end
+
+  def print?
+    user.status == "chairperson"
+  end
 end

--- a/app/views/layouts/application.pdf.erb
+++ b/app/views/layouts/application.pdf.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset='utf-8' />
+  </head>
+  <body>
+    <div id="content">
+      <%= yield %>
+    </div>
+  </body>
+</html>

--- a/app/views/shop_participants/stamped.html.erb
+++ b/app/views/shop_participants/stamped.html.erb
@@ -1,0 +1,1 @@
+<h1>hello from stamed!!</h1>

--- a/app/views/stamp_cards/new.html.erb
+++ b/app/views/stamp_cards/new.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for [@shop_participant, @stamp_card] do |f| %>
-  <%= f.input :qr_code, :as => :hidden, :input_html => { :value => "routes/for/shop_participants//stamped/" } %>
+  <%= f.input :qr_code, :as => :hidden, :input_html => { :value => "#{@shop_participant.id}/stamped!!" } %>
   <%= f.submit :submit,  class: "btn btn-success", value: "GET QR CODE!!" %>
 <% end %>
 
-<%# #{@shop_participant.id} %>
+<%# :value => "http://localhots:3000/participants/#{@participant.id}/stamp_cards/#{@stamp_card.id}/shop_participant/#{@shop_participant.id}/stamped" %>

--- a/app/views/stamp_cards/print.pdf.erb
+++ b/app/views/stamp_cards/print.pdf.erb
@@ -1,0 +1,8 @@
+<div class="container" style="text-align: center;">
+  <h1><%= @stamp_card.shop_participant.stamp_rally.name %></h1>
+  <h2><%= @shop_participant.shop.name %></h2>
+  <div class="qr-code">
+    <%= @svg.html_safe %>
+  </div>
+
+</div>

--- a/app/views/stamp_cards/show.html.erb
+++ b/app/views/stamp_cards/show.html.erb
@@ -1,4 +1,8 @@
-<div class="container">
-  <h1><%= @stamp_card.shop_participant.shop.name %></h1>
-  <%= @svg.html_safe %>
+<div class="container text-center">
+  <h1><%= @stamp_card.shop_participant.stamp_rally.name %></h1>
+  <h2><%= @shop_participant.shop.name %></h2>
+  <div class="qr-code mb-5">
+    <%= @svg.html_safe %>
+  </div>
+  <%= link_to "GENERATE PDF", print_shop_participant_stamp_card_path(@shop_participant, @stamp_card, format: :pdf), class: "btn btn-primary" %>
 </div>

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,0 +1,3 @@
+WickedPdf.config = {
+  :exe_path => "#{Gem.loaded_specs['wkhtmltopdf-binary'].full_gem_path}/bin/wkhtmltopdf"
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,11 +7,29 @@ Rails.application.routes.draw do
 
   #stamp cards are nested inside of the participating shops because we need to identify the specific shop in order to give the correct shop its stamp ---> one stamp belongs to one shop
   resources :shop_participants, only: %i[index] do
-    resources :stamp_cards, only: %i[show new create]
+    member do
+      post :stamped
+    end
+    resources :stamp_cards, only: %i[show new create] do
+      member do
+        get :print
+      end
+    end
   end
   resources :stamp_rallies, only: %i[index show new create]
   resources :shops, only: %i[index show new create]
   resources :stamp_cards, only: %i[index]
+
+  # belong to participants user journey
+  # resources :participants do
+    # resources :stamp_cards do
+    #   resources :shop_participants do
+    #     member do
+    #       post :stamped
+    #     end
+    #   end
+    # end
+  # end
 end
 
 # GET and POST  for ShopParticipant#stamped

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema[7.0].define(version: 2023_02_15_110614) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
added a new function to generate PDF data for QR Code show page. 

in the QR Code show page, when the user click the button "GENERATE PDF" 
then, we can get the PDF file with the QR code.

![スクリーンショット 2023-02-16 16 13 03](https://user-images.githubusercontent.com/112766207/219294315-b03b4343-e742-4641-a835-09ea04177bee.png)

![スクリーンショット 2023-02-16 16 12 53](https://user-images.githubusercontent.com/112766207/219294347-2c33446d-2b24-4b7c-8542-178030647e34.png)


This PDF file is coming from view file. 
If we want to change its styling, we can change these two files... 
  views/layouts/application.pdf.erb & views/stamp_cards/print.pdf.erb
But, application.scss in asset file and bootstrap won't work in these pdf files, so I embed style directory just for now. 
There might be some Rails helper to create file path which connects pdf.erb and stylesheets.(reference: https://github.com/mileszs/wicked_pdf)

 
 