### PR TITLE
GEOCODER - Add migration to create lat and lon for users location

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,9 @@ class User < ApplicationRecord
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  # geocoder
+  geocoded_by :location
+  after_validation :geocode, if: :will_save_change_to_location?
+
 end

--- a/app/views/stamp_rallies/show.html.erb
+++ b/app/views/stamp_rallies/show.html.erb
@@ -1,7 +1,8 @@
 <div class="container">
   <h1><%= @stamp_rally.name %></h1>
   <p><%= @stamp_rally.start_date %> ~ <%=  @stamp_rally.end_date %></p>
-  <%= @stamp_rally.description %>
+  <p>About this rally: <%= @stamp_rally.description %></p>
+  <p>Location: <%= @stamp_rally.user.location %></p>
 
   <h2>below shops appear in this rally!!</h2>
   <ul>

--- a/db/migrate/20230216071810_add_coordinates_to_users.rb
+++ b/db/migrate/20230216071810_add_coordinates_to_users.rb
@@ -1,0 +1,6 @@
+class AddCoordinatesToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :latitude, :float
+    add_column :users, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema[7.0].define(version: 2023_02_15_110614) do
-
+ActiveRecord::Schema[7.0].define(version: 2023_02_16_071810) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -109,6 +107,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_15_110614) do
     t.string "location"
     t.text "street_description"
     t.integer "status", default: 0
+    t.float "latitude"
+    t.float "longitude"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,9 +14,15 @@ User.destroy_all
 puts "Creating users..."
 
 User.create([
-  { email: "maria@example.com", password: "123456", status: 0 },
+  { email: "maria@example.com",
+    password: "123456",
+    status: 0,
+    location: "Higashimuki-nakamachi, Nara, Nara Prefecture, 630-8215, Japan" },
   { email: "mmak@example.com" , password: "123456", status: 0 },
-  { email: "jun@example.com", password: "123456", status: 1 },
+  { email: "jun@example.com",
+    password: "123456",
+    status: 1,
+    location: "Tarumi Ward, Kobe, Hyōgo Prefecture, Japan" },
   { email: "jay@example.com", password: "123456" , status: 0 }
             ])
 puts "Created four amazing users"


### PR DESCRIPTION
Changes: 
- I created a migration to add latitude and longitude coordinates for each user location
- Added some locations to two users in the seeds (that location will be the same for all the stamp rallies that user generates)
 We can access it with `@stamp_rally.user.location`