### PR TITLE
added css to shop view for a default size

### DIFF
--- a/app/assets/stylesheets/components/_shop.scss
+++ b/app/assets/stylesheets/components/_shop.scss
@@ -2,3 +2,8 @@
   width: 150px;
   height: auto;
 }
+
+.img-photos-for-show {
+  width: 300px;
+  height: auto;
+}

--- a/app/views/shops/_shop_info.html.erb
+++ b/app/views/shops/_shop_info.html.erb
@@ -1,7 +1,7 @@
 <div>
   <div>
     <% if @shop.photo.present? %>
-      <%= cl_image_tag @shop.photo.key%>
+      <%= cl_image_tag @shop.photo.key, class:'img-photos-for-show ' %>
     <% elsif %>
       <%= image_tag 'panda.jpg', class: 'img-test' %>
     <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema[7.0].define(version: 2023_02_16_071810) do
-
+ActiveRecord::Schema[7.0].define(version: 2023_02_16_104907) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,8 +71,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_16_071810) do
     t.text "description"
     t.float "latitude"
     t.float "longitude"
-    t.string "category_icon"
     t.string "photo"
+    t.string "category_icon"
     t.index ["user_id"], name: "index_shops_on_user_id"
   end
 


### PR DESCRIPTION
![スクリーンショット 2023-02-16 21 19 01](https://user-images.githubusercontent.com/109736023/219362932-97c06a12-8430-4b1c-aba4-1305be0d88e1.png)

I set a CSS to make a default size for images, to smaller, for ease of view of the images on shop view. 

This can be edited later under components for CSS