### PR TITLE
Delete See all Rallies and rallies button when chairperson signed in

### DIFF
--- a/app/views/pages/_chairperson_dash.html.erb
+++ b/app/views/pages/_chairperson_dash.html.erb
@@ -17,7 +17,6 @@
     <div class="dash-rallies">
       <div class="d-flex align-items-center justify-content-between">
         <h4>Stamp rallies</h4>
-        <p><%= link_to "See all", "#", class: "btn btn-primary"%></p>
       </div>
 
       <div class="rallies-container">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -8,7 +8,6 @@
       <ul class="nav">
         <li><%= link_to "Dashboard", dashboard_path %></li>
         <li><%= link_to "Shops", shops_path %></li>
-        <li><%= link_to "Rallies", stamp_rallies_path %></li>
       </ul>
     <% else %>
       <ul class="nav">

--- a/app/views/shared/_offcanvas.html.erb
+++ b/app/views/shared/_offcanvas.html.erb
@@ -24,7 +24,6 @@
         <ul class="offcanvas-nav">
           <li><%= link_to "Dashboard", dashboard_path %></li>
           <li><%= link_to "Shops", shops_path %></li>
-          <li><%= link_to "Rallies", stamp_rallies_path %></li>
         </ul>
       <% else %>
         <ul class="offcanvas-nav">


### PR DESCRIPTION
Changes: 
- Deleted the "Rallies" link on the navbar, offcanvas and from the dashboard when the chairperson is logged in. We don't need the rallies index view for that type of user, only for the participants.

<img width="1428" alt="Captura de Pantalla 2023-02-17 a las 9 43 33" src="https://user-images.githubusercontent.com/70474104/219520561-1abc3a6c-f9fd-45ec-8f64-4292e8e1adc4.png">
