### PR TITLE
Display status of stamp rally depending on dates

### DIFF
--- a/app/assets/stylesheets/components/_card_stamp_rally.scss
+++ b/app/assets/stylesheets/components/_card_stamp_rally.scss
@@ -11,30 +11,44 @@
   padding: 15px;
   margin-bottom: 20px;
   border-radius: 12px;
-  background: #fff;
   transition: ease-out 0.6s;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  transition: 0.2s ease-out;
   &:hover {
     color: #000;
-    background: rgb(238, 238, 238);
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
   }
   .rally-title {
     font-weight: bold;
   }
-  .tag {
-    background: orange;
+
+  .date {
+    background: rgba(255, 255, 255, 0.347);
+    display: inline;
+    padding: 3px 15px;
+    border-radius: 50px;
   }
 }
 
 .ongoing {
-  background: $blue;
+  background: $lightblue;
   &:hover {
-    background: darken($blue, 10%)
+    background: darken($lightblue, 3%);
   }
   .tag {
-    background: blue;
+    background: $blue;
+  }
+}
+
+.soon {
+  background: $lightorange;
+  &:hover {
+    background: darken($lightorange, 3%);
+  }
+  .tag {
+    background: $orange;
   }
 }
 

--- a/app/assets/stylesheets/components/_card_stamp_rally.scss
+++ b/app/assets/stylesheets/components/_card_stamp_rally.scss
@@ -29,7 +29,10 @@
 }
 
 .ongoing {
-  background: rgb(96, 166, 134);
+  background: $blue;
+  &:hover {
+    background: darken($blue, 10%)
+  }
   .tag {
     background: blue;
   }

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -3,10 +3,12 @@
 // For example:
 $red: #FD1015;
 $blue: #326ef2;
+$lightblue: #6e97f0;
 $yellow: #FFC65A;
 $orange: #cd5326;
+$lightorange: #f69673;
 $green: #1EDD88;
-$gray: #0E0000;
+$gray: #2D3142;
 $light-gray: #F4F4F4;
 
 // IDEAS FOR COLORS

--- a/app/models/stamp_rally.rb
+++ b/app/models/stamp_rally.rb
@@ -9,4 +9,8 @@ class StampRally < ApplicationRecord
   validates :end_date, presence: true
   validates :name, presence: true, length: { in: 5..50 }
   validates :description, length: { in: 10..300 }
+
+  # def ongoing?
+  #   Date.today.between?(self.stamp_rally.start_date, self.stamp_rally.end_date)
+  # end
 end

--- a/app/views/pages/_chairperson_dash.html.erb
+++ b/app/views/pages/_chairperson_dash.html.erb
@@ -1,5 +1,5 @@
 <div class="container chair-dashboard py-5">
-  <div class="dash-user mb-3">
+  <div class="dash-user mb-5">
     <div class="mb-3">
       <h1>Welcome back, <%= current_user.email.split("@").first.capitalize %></h1>
       <p>Chairman of Shioya Street</p>
@@ -25,7 +25,7 @@
     </div>
 
     <div class="dash-main">
-    
+
       <%# Stadisticst for chairman %>
       <div class="stadistics"></div>
 

--- a/app/views/pages/_rallies_list.html.erb
+++ b/app/views/pages/_rallies_list.html.erb
@@ -1,15 +1,15 @@
 <% @stamprallies.each do |rally| %>
   <%= link_to stamp_rally_path(rally) do %>
-    <div class="rally-card <%= if Date.today > rally.end_date
+    <div class="rally-card <%= if rally.end_date.past?
       "finished"
-      elsif (Date.today > rally.start_date && Date.today < rally.end_date)
+      elsif Date.today.between?(rally.start_date, rally.end_date)
         "ongoing"
       else
         "soon"
       end %>">
       <div>
         <p class="rally-title"><%= rally.name %></p>
-        <%= rally.start_date.to_s.split(" ").first %> - <%= rally.end_date.to_s.split(" ").first %></p>
+        <%= rally.start_date %> - <%= rally.end_date %></p>
       </div>
       <%= pluralize(rally.shop_participants.count, "shop") %>
       <% if Date.today > rally.end_date %>

--- a/app/views/pages/_rallies_list.html.erb
+++ b/app/views/pages/_rallies_list.html.erb
@@ -8,8 +8,8 @@
         "soon"
       end %>">
       <div>
-        <p class="rally-title"><%= rally.name %></p>
-        <%= rally.start_date %> - <%= rally.end_date %></p>
+        <h6 class="rally-title"><%= rally.name %></h6>
+        <p class="date"><%= rally.start_date %> - <%= rally.end_date %></p>
       </div>
       <%= pluralize(rally.shop_participants.count, "shop") %>
       <% if Date.today > rally.end_date %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -152,7 +152,7 @@ StampRally.create(
   name: "Shioya Stamp Rally spring 2023",
   description: "Celebrate the arrival of spring at Shioya Street!",
   start_date: "2023-02-01",
-  end_date: "2022-03-20",
+  end_date: "2023-03-20",
   user: User.third
 )
 


### PR DESCRIPTION
Changes: 
- Fixed the conditions on the dashboard, now the stamp rallies have three stages depending on the dates: ongoing, coming soon or finished. 
- Changed the ongoing one to a blue background

<img width="630" alt="Captura de Pantalla 2023-02-17 a las 21 18 29" src="https://user-images.githubusercontent.com/70474104/219651831-57c49918-07ab-4c89-900e-45d25db459d7.png">


After the second commit: 
<img width="810" alt="Captura de Pantalla 2023-02-17 a las 21 36 52" src="https://user-images.githubusercontent.com/70474104/219655274-dd8645c6-3ef3-4c0c-87a7-e5fe0566e04b.png">

