### PR TITLE
Rally map

### DIFF
--- a/app/assets/stylesheets/components/_card_stamp_rally.scss
+++ b/app/assets/stylesheets/components/_card_stamp_rally.scss
@@ -19,18 +19,42 @@
     color: #000;
     box-shadow: 0 0 15px rgba(0,0,0,0.2);
   }
-
   .rally-title {
     font-weight: bold;
+  }
+  .date-status {
+    @media(max-width: 576px) {
+      align-items: center;
+      display: flex;
+      flex-direction: column;
+    }
   }
 }
 
 .dates {
+  display: flex;
   background: rgba(255, 255, 255, 0.363);
-  display: inline;
-  padding: 3px 15px;
   border-radius: 50px;
+  max-width: 220px;
+  p {
+    margin-bottom: 0;
+    display: inline;
+    padding: 3px 15px;
+    border-radius: 50px;
+  }
+  @media(max-width: 576px) {
+    flex-direction: column;
+    background: none;
+    p {
+      background: rgba(255, 255, 255, 0.363);
+      margin-bottom: 10px;
+      border-radius: 50px;
+      max-width: 110px;
+      font-size: 14px;
+    }
+  }
 }
+
 
 .ongoing {
   background: $lightblue;
@@ -73,8 +97,4 @@
   border-radius: 5px;
   margin: 10px 0px;
   background: #fff;
-}
-
-.tag {
-  font-weight: bold;
 }

--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -3,8 +3,13 @@
   width: 900px;
   position: fixed;
   @media(max-width: 992px) {
-    width: 100%;
+    padding-top: 300px;
     height: 300px;
+    width: 100%;
+  }
+  @media(max-width: 556px) {
+    padding-top: 200px;
+    height: 200px;
   }
 }
 
@@ -36,4 +41,15 @@
   font-size: 40px;
   color: #000;
   margin-right: 10px;
+}
+
+
+// RALLY MAP
+.rally-map {
+  height: 87vh;
+  width: 900px;
+  @media(max-width: 992px) {
+    height: 300px;
+    width: 100%;
+  }
 }

--- a/app/assets/stylesheets/components/_tag.scss
+++ b/app/assets/stylesheets/components/_tag.scss
@@ -3,6 +3,10 @@
   border-radius: 50px;
   display: inline-block;
   font-size: 14px;
+  font-weight: bold;
   letter-spacing: 1px;
   color: #fff;
+  @media(max-width: 576px) {
+    font-size: 10px;
+  }
 }

--- a/app/assets/stylesheets/config/_structure.scss
+++ b/app/assets/stylesheets/config/_structure.scss
@@ -22,22 +22,23 @@ body {
 }
 
 @media (max-width: 992px) {
-  body {
-    height: auto;
-  }
+  // body {
+  //   height: auto;
+  // }
 
   .content {
     border-radius: 0px;
     margin: 0;
-    height: 100%;
+    height: 87vh;
   }
 
   .view-container {
     flex-direction: column-reverse;
+    justify-content: flex-end;
   }
 
   .scroll-content {
-    height: 100%;
+    overflow-y: scroll;
     margin-bottom: 30px;
   }
 }

--- a/app/views/pages/_rallies_list.html.erb
+++ b/app/views/pages/_rallies_list.html.erb
@@ -9,16 +9,21 @@
       end %>">
       <div>
         <h6 class="rally-title"><%= rally.name %></h6>
-        <p class="dates"><%= rally.start_date %> - <%= rally.end_date %></p>
+        <div class="dates">
+          <p><%= rally.start_date %></p>
+          <p><%= rally.end_date %></p>
+        </div>
       </div>
-      <%= pluralize(rally.shop_participants.count, "shop") %>
-      <% if Date.today > rally.end_date %>
-        <p class="tag">Finished</p>
-      <% elsif Date.today > rally.start_date && Date.today < rally.end_date %>
-        <p class="tag">Ongoing</p>
-      <% else %>
-        <p class="tag">Coming soon</p>
-      <% end %>
+      <div class="date-status">
+        <p><%= pluralize(rally.shop_participants.count, "shop") %></p>
+        <% if Date.today > rally.end_date %>
+          <p class="tag">Finished</p>
+        <% elsif Date.today > rally.start_date && Date.today < rally.end_date %>
+          <p class="tag">Ongoing</p>
+        <% else %>
+          <p class="tag">Coming soon</p>
+        <% end %>
+      </div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/stamp_rallies/index.html.erb
+++ b/app/views/stamp_rallies/index.html.erb
@@ -16,7 +16,10 @@
               end %>">
               <div>
                 <h6 class="rally-title"><%= rally.name %></h6>
-                <p class="date"><%= rally.start_date %> - <%= rally.end_date %></p>
+                <div class="dates">
+                  <p><%= rally.start_date %></p>
+                  <p><%= rally.end_date %></p>
+                </div>
               </div>
               <div class="date-status">
                 <p><%= pluralize(rally.shop_participants.count, "shop") %></p>

--- a/app/views/stamp_rallies/index.html.erb
+++ b/app/views/stamp_rallies/index.html.erb
@@ -1,40 +1,42 @@
 <div class="view-container">
 
-  <div class="container py-5">
+  <div class="scroll-content container">
+    <div class="padding">
+      <h1 class="mb-5">Our popular Stamp Rallies</h1>
 
-    <h1 class="mb-5">Our popular Stamp Rallies</h1>
-
-    <% @stamp_rallies.each do |rally| %>
-      <% unless rally.end_date.past? %>
-        <%= link_to stamp_rally_path(rally) do %>
-          <div class="rally-card <%= if rally.end_date.past?
-              "finished"
-            elsif Date.today.between?(rally.start_date, rally.end_date)
-              "ongoing"
-            else
-              "soon"
-            end %>">
-            <div>
-              <h6 class="rally-title"><%= rally.name %></h6>
-              <p class="date"><%= rally.start_date %> - <%= rally.end_date %></p>
+      <% @stamp_rallies.each do |rally| %>
+        <% unless rally.end_date.past? %>
+          <%= link_to stamp_rally_path(rally) do %>
+            <div class="rally-card <%= if rally.end_date.past?
+                "finished"
+              elsif Date.today.between?(rally.start_date, rally.end_date)
+                "ongoing"
+              else
+                "soon"
+              end %>">
+              <div>
+                <h6 class="rally-title"><%= rally.name %></h6>
+                <p class="date"><%= rally.start_date %> - <%= rally.end_date %></p>
+              </div>
+              <div class="date-status">
+                <p><%= pluralize(rally.shop_participants.count, "shop") %></p>
+                <% if Date.today > rally.end_date %>
+                  <p class="tag">Finished</p>
+                <% elsif Date.today > rally.start_date && Date.today < rally.end_date %>
+                  <p class="tag">Ongoing</p>
+                <% else %>
+                  <p class="tag">Coming soon</p>
+                <% end %>
+              </div>
             </div>
-            <%= pluralize(rally.shop_participants.count, "shop") %>
-            <% if Date.today > rally.end_date %>
-              <p class="tag">Finished</p>
-            <% elsif Date.today > rally.start_date && Date.today < rally.end_date %>
-              <p class="tag">Ongoing</p>
-            <% else %>
-              <p class="tag">Coming soon</p>
-            <% end %>
-          </div>
+          <% end %>
         <% end %>
       <% end %>
-    <% end %>
+    </div>
 
   </div>
 
   <div class="rally-map"
-  style="width: 100%; height: 600px;"
   data-controller="rally-map"
   data-rally-map-markers-value="<%= @markers.to_json %>"
   data-rally-map-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>"></div>


### PR DESCRIPTION
Changes: 
- Make map for shops and rallies to stay at the top of the page on smaller screens and the list bellow with overflow: scroll
- Make stamp rally cards responsive on smaller screens

<img width="514" alt="Captura de Pantalla 2023-02-21 a las 13 04 10" src="https://user-images.githubusercontent.com/70474104/220244823-178df7c2-991b-4246-a73d-21659abfa739.png">

![Feb-21-2023 13-12-20](https://user-images.githubusercontent.com/70474104/220246041-f4c51bd3-85ac-44cb-811b-53ed04094e0a.gif)

