### PR TITLE
Seeds for Nara shops and rally and links to shops

### DIFF
--- a/app/views/stamp_rallies/_shop_participants.erb
+++ b/app/views/stamp_rallies/_shop_participants.erb
@@ -1,26 +1,28 @@
 <div class="shops-container-rally">
   <% @stamp_rally.shop_participants.each do |shop_participant| %>
-    <div class="shop-card-rally">
-      <% if shop_participant.shop.photo.attached? %>
-        <%= cl_image_tag shop_participant.shop.photo.key, class: "shop-img" %>
-      <% else %>
-        <%= image_tag 'https://images.unsplash.com/photo-1612014449419-ac12de2f2181?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80', class: "shop-img" %>
-      <% end %>
-
-      <div class="shop-content">
-        <h5><%= shop_participant.shop.name %></h5>
-
-        <%# QR code button %>
-        <% if user_signed_in? %>
-          <% if current_user.status == "chairperson" %>
-            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal<%= shop_participant.id %>">
-              QR Code
-            </button>
-            <%= render "modal", shop_participant: shop_participant %>
-          <% end %>
+    <%= link_to shop_path(shop_participant.shop) do %>
+      <div class="shop-card-rally">
+        <% if shop_participant.shop.photo.attached? %>
+          <%= cl_image_tag shop_participant.shop.photo.key, class: "shop-img" %>
+        <% else %>
+          <%= image_tag 'https://images.unsplash.com/photo-1612014449419-ac12de2f2181?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80', class: "shop-img" %>
         <% end %>
+
+        <div class="shop-content">
+          <h5><%= shop_participant.shop.name %></h5>
+
+          <%# QR code button %>
+          <% if user_signed_in? %>
+            <% if current_user.status == "chairperson" %>
+              <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal<%= shop_participant.id %>">
+                QR Code
+              </button>
+              <%= render "modal", shop_participant: shop_participant %>
+            <% end %>
+          <% end %>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
 </div>
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,7 +29,8 @@ User.create([
             ])
 puts "Created four amazing users"
 
-puts "seeding 9 shops..."
+
+puts "1. Seeding 9 shops for Shioya Street..."
 
 shopone = Shop.create(
   name: "Shirochan",
@@ -39,6 +40,7 @@ shopone = Shop.create(
   description: "Umai Yasui Teishoku",
   user: User.third
 )
+
 imgone = URI.open("https://res.cloudinary.com/diohufzdn/image/upload/v1676548462/Shirochan_ii75ig.jpg")
 shopone.photo.attach(io: imgone, filename: "photo")
 
@@ -132,10 +134,10 @@ shopnine.photo.attach(io: imgnine, filename: "photo")
 
 
 
-puts "Generated 9 shops"
+puts "Generated 9 shops for Shioya Street"
 
 
-puts "Creating stamp rallies..."
+puts "Creating stamp rallies in Shioya Area"
 
 StampRally.create(
   name: "Shioya Stamp Rally winter 2022",
@@ -164,11 +166,11 @@ StampRally.create(
   location: User.third.location
 )
 
+puts "Created stamp rallies in Shioya Area"
+
 
 # CREATE SHOP PARTICIPANTS FOR EXISTING RALLIES:
-
 puts "Creating shop participants..."
-
 
 # SHIOYA RALLY ID:1
 rally1_count = 0
@@ -216,5 +218,128 @@ end
 
 
 puts "Created participants for stamp rally with id 3"
+puts "Created data for Shioya Shops"
+
+puts "2. Seeding 8 shops for Naramachi..."
+
+nara1 = Shop.create(
+  name: "Fuku Roku Dou",
+  address: "〒630-8215 Nara, Higashimuki Nakamachi, 27 HIKARIビル1～3F",
+  category: "Restaurant",
+  category_icon: "resutoran",
+  description: "Castella shop",
+  user: User.first
+)
+
+# nara1 = URI.open("")
+# nara1.photo.attach(io: imgnine, filename: "photo")
+
+
+nara2 = Shop.create(
+  name: "Cafe FLUKE",
+  address: "奈良市東向中町10",
+  category: "Coffee",
+  category_icon: "kissaten",
+  description: "Retro coffee in Naramachi",
+  user: User.first
+)
+
+# nara2 = URI.open("")
+# nara2.photo.attach(io: imgnine, filename: "photo")
+
+
+nara3 = Shop.create(
+  name: "奈良ism",
+  address: "東向南町23-2",
+  category: "Izakaya",
+  category_icon: "izakaya",
+  description: "Newly open izakaya in Naramachi with regional food, more than 70 different dishes!",
+  user: User.first
+)
+
+# nara3 = URI.open("")
+# nara3.photo.attach(io: imgnine, filename: "photo")
+
+
+nara4 = Shop.create(
+  name: "HEX HIVE",
+  address: "奈良市東向南町3",
+  category: "Shop",
+  category_icon: "baiten",
+  description: "Second hand articles",
+  user: User.first
+)
+
+# nara4 = URI.open("")
+# nara4.photo.attach(io: imgnine, filename: "photo")
+
+
+nara5 = Shop.create(
+  name: "Oshaberi na kame",
+  address: "奈良市東向南町28-1",
+  category: "Coffee",
+  category_icon: "kissaten",
+  description: "Retro coffee shop with very yummy omurice",
+  user: User.first
+)
+
+# nara5 = URI.open("")
+# nara5.photo.attach(io: imgnine, filename: "photo")
+
+
+nara6 = Shop.create(
+  name: "Ramen K",
+  address: "9 Komyoincho, Nara, 630-8371",
+  category: "Ramen",
+  category_icon: "ramen",
+  description: "Speciality ramen",
+  user: User.first
+)
+
+# nara6 = URI.open("")
+# nara6.photo.attach(io: imgnine, filename: "photo")
+
+puts "Generated 6 shops for Naramachi"
+
+puts "Creating stamp rallies in Naramachi"
+
+StampRally.create(
+  name: "Naramachi Winter 2022",
+  description: "Winter stamp rally, enjoy japanese food with some winter decorations and seasonal food",
+  start_date: "2022-1-20",
+  end_date: "2022-2-10",
+  user: User.first,
+  location: User.first.location
+)
+
+StampRally.create(
+  name: "Naramachi deer festival",
+  description: "Shops reunited to get donations for deer association",
+  start_date: "2023-2-10",
+  end_date: "2023-3-20",
+  user: User.first,
+  location: User.first.location
+)
+
+puts "Created stamp rallies in Naramachi"
+
+# CREATE SHOP PARTICIPANTS FOR EXISTING RALLIES:
+puts "Creating shop participants..."
+
+# SHIOYA RALLY ID:1
+rally1_count = 10
+n = 10
+
+until rally1_count == 15
+  ShopParticipant.create(
+    shop: Shop.all[rally1_count],
+    stamp_rally: StampRally.last,
+    qr_code: "#{n}/stamped"
+  )
+  rally1_count += 1
+  n += 1
+end
+
+puts "Created participants for stamp rally with id 1"
 
 puts "Finished!"


### PR DESCRIPTION
Changes: 
- Created seeds for 6 shops and stamp rallies in Nara
- Added links to shop view from the shop cards in the rally show page (so the participants can check each shop information page from the stamp rally show page)