### PR TITLE
debugged the problem of adding participant and instances multiple times

### DIFF
--- a/app/controllers/stamp_cards_controller.rb
+++ b/app/controllers/stamp_cards_controller.rb
@@ -18,9 +18,7 @@ class StampCardsController < ApplicationController
   end
 
   def create
-    @participant = Participant.new(user: current_user)
-    @participant.stamp_rally = @stamp_rally
-    @participant.save
+    @participant = Participant.find(params[:participant_id])
     @stamp_card = StampCard.new(participant: @participant, stamp_rally: @stamp_rally)
     authorize @stamp_card
     @stamp_card.save

--- a/app/controllers/stamp_rallies_controller.rb
+++ b/app/controllers/stamp_rallies_controller.rb
@@ -38,7 +38,11 @@ class StampRalliesController < ApplicationController
       else
         @participant = Participant.new(user: current_user)
         @participant.stamp_rally = @stamp_rally
-        @participant.save
+        if Participant.where(user: current_user, stamp_rally: @stamp_rally).count == 0
+          @participant.save
+        else
+          @participant = Participant.where(user: current_user, stamp_rally: @stamp_rally).first
+        end
         @stamp_card = StampCard.new
       end
     end

--- a/app/views/stamp_rallies/show.html.erb
+++ b/app/views/stamp_rallies/show.html.erb
@@ -30,8 +30,12 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
               </div>
               <div class="modal-body">
+              <% if StampCard.where(participant: @participant, stamp_rally: @stamp_rally).count == 0 %>
                 <h2>Stamp Card gets ready now!!!</h2>
                 <%= render "stamp_cards/new", stamp_rally: @stamp_rally, participant: @participant %>
+              <% else %>
+                <h2>You have already joined this rally!!</h2>
+              <% end %>
               </div>
             </div>
           </div>


### PR DESCRIPTION
modify my logic when creating Participant and Stamp Card instances.
these instances will no longer be duplicated.

If the user gets the stamp card for the same stamp rally event, the modal screen will say "You have already joined this rally."

![スクリーンショット 2023-02-22 16 13 37](https://user-images.githubusercontent.com/112766207/220550278-f458de69-2854-4365-82c8-71315d182acf.png)
