### PR TITLE
Hide join stamp rally button and controller changes

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,7 +4,11 @@ class PagesController < ApplicationController
   def home; end
 
   def dashboard
-    @shops = policy_scope(Shop).last(4)
+    if user_signed_in?
+      if current_user.status == "chairperson"
+        @shops = policy_scope(Shop).where(user_id: current_user).last(4)
+      end
+    end
     @stamprallies = policy_scope(StampRally).all
   end
 end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -3,7 +3,7 @@ class ShopsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
 
   def index
-    @shops = policy_scope(Shop).all
+    @shops = policy_scope(Shop).where(user_id: current_user)
     # The `geocoded` scope filters only flats with coordinates
     @markers = @shops.geocoded.map do |shop|
       {

--- a/app/views/pages/_rallies_list.html.erb
+++ b/app/views/pages/_rallies_list.html.erb
@@ -1,24 +1,26 @@
 <% @stamprallies.each do |rally| %>
-  <%= link_to stamp_rally_path(rally) do %>
-    <div class="rally-card <%= if rally.end_date.past?
-      "finished"
-      elsif Date.today.between?(rally.start_date, rally.end_date)
-        "ongoing"
-      else
-        "soon"
-      end %>">
-      <div>
-        <h6 class="rally-title"><%= rally.name %></h6>
-        <p class="dates"><%= rally.start_date %> - <%= rally.end_date %></p>
+  <% if rally.user_id == current_user.id %>
+    <%= link_to stamp_rally_path(rally) do %>
+      <div class="rally-card <%= if rally.end_date.past?
+        "finished"
+        elsif Date.today.between?(rally.start_date, rally.end_date)
+          "ongoing"
+        else
+          "soon"
+        end %>">
+        <div>
+          <h6 class="rally-title"><%= rally.name %></h6>
+          <p class="dates"><%= rally.start_date %> - <%= rally.end_date %></p>
+        </div>
+        <%= pluralize(rally.shop_participants.count, "shop") %>
+        <% if Date.today > rally.end_date %>
+          <p class="tag">Finished</p>
+        <% elsif Date.today > rally.start_date && Date.today < rally.end_date %>
+          <p class="tag">Ongoing</p>
+        <% else %>
+          <p class="tag">Coming soon</p>
+        <% end %>
       </div>
-      <%= pluralize(rally.shop_participants.count, "shop") %>
-      <% if Date.today > rally.end_date %>
-        <p class="tag">Finished</p>
-      <% elsif Date.today > rally.start_date && Date.today < rally.end_date %>
-        <p class="tag">Ongoing</p>
-      <% else %>
-        <p class="tag">Coming soon</p>
-      <% end %>
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/stamp_rallies/_join_button.html.erb
+++ b/app/views/stamp_rallies/_join_button.html.erb
@@ -1,20 +1,20 @@
 <%#====== for new user journey ========%>
 <!-- Button trigger modal -->
 
-<div data-bs-toggle="modal" data-bs-target="#joinTheRally">
-  <%# <%= render "participants/new", stamp_rally: @stamp_rally %> %>
-  <p>Join this rally</p>
-</div>
+<button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#joinTheRally">
+  Join this rally
+</button>
 
 <!-- Modal -->
 <div class="modal fade" id="joinTheRally" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
+        <p>You successfully joined this stamp rally</p>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <h2>Stamp Card gets ready now!!!</h2>
+        <h3>Start collecting Stamps!</h3>
         <%= render "stamp_cards/new", stamp_rally: @stamp_rally, participant: @participant %>
       </div>
     </div>

--- a/app/views/stamp_rallies/show.html.erb
+++ b/app/views/stamp_rallies/show.html.erb
@@ -14,31 +14,11 @@
 
     <% if user_signed_in? %>
       <% if current_user.status == "user" %>
-
-        <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#joinTheRally">
-          <%# <%= render "participants/new", stamp_rally: @stamp_rally %>
-          <h2>JOIN This Rally?</h2>
-        </button>
-
-        <!-- Modal -->
-        <div class="modal fade" id="joinTheRally" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <div class="modal-header">
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-              </div>
-              <div class="modal-body">
-              <% if StampCard.where(participant: @participant, stamp_rally: @stamp_rally).count == 0 %>
-                <h2>Stamp Card gets ready now!!!</h2>
-                <%= render "stamp_cards/new", stamp_rally: @stamp_rally, participant: @participant %>
-              <% else %>
-                <h2>You have already joined this rally!!</h2>
-              <% end %>
-              </div>
-            </div>
-          </div>
-        </div>
-
+        <% if StampCard.where(participant: @participant, stamp_rally: @stamp_rally).count == 0 %>
+          <%= render "join_button" %>
+        <% else %>
+          <p><strong>You are already a participant of this stamp rally</strong></p>
+        <% end %>
       <% end %>
     <% else %> <%# if user not signed in  %>
       <p>You need to login to join this stamp rally</p>


### PR DESCRIPTION
Changes: 
- Following the changes that Jun made before, I hide the "Join stamp rally" button if the user is already a participant on that one. 
- I made changes in the pages and shops controller on the chairperson flow. When we are logged in as chairperson, on the dashboard only the stamp rallies and the shops created by that person will appear.