### PR TITLE
Link to stamp cards and map view

### DIFF
--- a/app/controllers/stamp_cards_controller.rb
+++ b/app/controllers/stamp_cards_controller.rb
@@ -8,7 +8,7 @@ class StampCardsController < ApplicationController
 
   def show
     @participant = Participant.find(params[:participant_id])
-    @stamp_card = StampCard.find(params[:id])
+    @stamp_card = StampCard.find(params[:participant_id])
     authorize @stamp_card
   end
 

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1,5 +1,6 @@
 class Participant < ApplicationRecord
   belongs_to :user
   belongs_to :stamp_rally
+  has_many :stamp_cards
   has_many :shop_participants, through: :stamp_card
 end

--- a/app/views/pages/_user_dash.html.erb
+++ b/app/views/pages/_user_dash.html.erb
@@ -27,7 +27,7 @@
                 </div>
                 <div>
                   <%= link_to "Stamps", stamp_rally_participant_stamp_card_path(@stamp_rally, participant, participant.stamp_cards) %>
-                  <%= link_to "Go to map", "#" %>
+                  <%= link_to "Go to map", stamp_rally_shop_participants_path(@stamp_rally) %>
                 </div>
               </div>
             <% end %>

--- a/app/views/pages/_user_dash.html.erb
+++ b/app/views/pages/_user_dash.html.erb
@@ -19,14 +19,14 @@
           <%# *** declare this variable to keep code DRY ***%>
           <% @stamp_rally = participant.stamp_rally %>
           <% @shop_participants = @stamp_rally.shop_participants %>
-            <%= link_to "#" do %>
+            <%= link_to stamp_rally_path(@stamp_rally) do %>
               <div class="rally-card ongoing">
                 <div>
                   <h6 class="rally-title"><%= @stamp_rally.name %></h6>
                   <p class="mb-0">0 / <%= pluralize(@stamp_rally.shop_participants.count, "stamp") %> collected</p>
                 </div>
                 <div>
-                  <%= link_to "Stamps", "#" %>
+                  <%= link_to "Stamps", stamp_rally_participant_stamp_card_path(@stamp_rally, participant, participant.stamp_cards) %>
                   <%= link_to "Go to map", "#" %>
                 </div>
               </div>

--- a/app/views/shop_participants/index.html.erb
+++ b/app/views/shop_participants/index.html.erb
@@ -1,0 +1,3 @@
+
+
+<h1>hello from shop participants!!</h1>

--- a/app/views/stamp_cards/show.html.erb
+++ b/app/views/stamp_cards/show.html.erb
@@ -2,7 +2,7 @@
 
   <%= link_to "Back to profile", dashboard_path %>
   <h3 class="mb-3">Stamps for <%= @stamp_card.stamp_rally.name %></h3>
-  <%= link_to "Map view", "#", class: "btn btn-primary mb-3" %>
+  <%= link_to "Map view", stamp_rally_shop_participants_path(@stamp_card.stamp_rally), class: "btn btn-primary mb-3" %>
 
   <div class="stamp-cards-container">
     <% @shop_participants = @stamp_card.stamp_rally.shop_participants %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   # participant's user journey
   resources :stamp_rallies, only: %i[index show] do
     resources :participants, only: %i[new create] do
-      resources :stamp_cards, only: %i[index new show create] do
+      resources :stamp_cards, only: %i[index show new create] do
         resources :shop_participants, only: %i[index] do
           member do
             post :stamped

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     resources :participants, only: %i[new create] do
       resources :stamp_cards, only: %i[index show new create] do
         resources :shop_participants, only: %i[index] do
+          # is this the map view...?
           member do
             post :stamped
           end
@@ -30,8 +31,10 @@ Rails.application.routes.draw do
   end
   resources :shops, only: %i[index show new create]
 end
-# GET and POST  for ShopParticipant#stamped
 
+
+
+# GET and POST  for ShopParticipant#stamped
 # ==========previous reoutes================
 # resources :shop_participants, only: %i[index] do
 #   member do


### PR DESCRIPTION
Changes: 
- Added link to stamp_cards show page from the user dashboard
- Added link to map view: this will be a page with a map that shows the shop participants for an especific stamp rally. From there, whenever we click on a shop, we have the option to scan the QR code and change the status for that shop to stamped.