### PR TITLE
Make landing page headers and text smaller on phone screens

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -13,6 +13,17 @@
       font-size: 50px;
     }
   }
+  @media(max-width: 576px) {
+    .landing-content {
+      .wide-logo {
+        font-size: 24px;
+      }
+      h3 {
+        font-size: 18px;
+      }
+    }
+
+  }
 }
 
 // about section
@@ -56,6 +67,7 @@
     .section-content {
       padding: 30px;
       width: 50%;
+      font-size: 18px;
       h3 {
         color: $blue;
       }


### PR DESCRIPTION
Changes: 
- Made headers and p tags font size smaller on small screens
(The navbar width and the left margin of the text is fixed in the pull request #106 )

<img width="361" alt="Captura de Pantalla 2023-02-24 a las 14 58 15" src="https://user-images.githubusercontent.com/70474104/221103647-1ba25ce4-67f0-4c75-80a5-b50640216de2.png">
