### PR TITLE
Style shop cards

### DIFF
--- a/app/assets/stylesheets/components/_card-shop.scss
+++ b/app/assets/stylesheets/components/_card-shop.scss
@@ -55,7 +55,7 @@
     margin-bottom: 10px;
     grid-template-columns: 1fr 1fr;
   }
-  @media(max-width: 576px) {
+  @media(max-width: 350px) {
     grid-template-columns: 1fr;
   }
 }
@@ -72,7 +72,7 @@
     padding: 20px;
   }
   img {
-    max-height: 130px;
+    max-height: 150px;
     border-radius: 5px;
     border-bottom-right-radius: 0px;
     border-bottom-left-radius: 0px;
@@ -80,6 +80,7 @@
   &:hover {
     color: #000;
     box-shadow: 0px 4px 40px rgba(0,0,0,0.2);
+    transform: scale(1.01);
   }
 }
 
@@ -101,7 +102,7 @@
     grid-template-columns: 1fr 1fr;
 
   }
-  @media(max-width: 576px) {
+  @media(max-width: 350px) {
     grid-template-columns: 1fr;
   }
 }
@@ -114,11 +115,15 @@
   background: #fff;
   position: relative;
   transition: 0.2s ease-out;
+  position: relative;
   .shop-content {
     padding: 20px;
+    @media(max-width: 576px) {
+      padding: 10px;
+    }
   }
   img {
-    max-height: 200px;
+    max-height: 150px;
     border-radius: 5px;
     border-bottom-right-radius: 0px;
     border-bottom-left-radius: 0px;
@@ -127,5 +132,18 @@
     cursor: pointer;
     color: #000;
     box-shadow: 0px 4px 40px rgba(0,0,0,0.2);
+    transform: scale(1.01);
   }
+}
+
+// icons on top of images
+.relative-jpic {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  padding: 10px;
+  background: white;
+  font-size: 22px !important;
+  border-radius: 16px;
+  box-shadow: 0 0 15px rgba(0,0,0,0.2);
 }

--- a/app/assets/stylesheets/components/_stamp_card.scss
+++ b/app/assets/stylesheets/components/_stamp_card.scss
@@ -72,7 +72,6 @@
   border-radius: 16px;
   box-shadow: 0 0 15px rgba(0,0,0,0.2);
   transition: all .2s ease-in-out;
-
   .jpic {
     font-size: 22px;
     margin: 0px;

--- a/app/views/shops/_shops.html.erb
+++ b/app/views/shops/_shops.html.erb
@@ -3,12 +3,14 @@
     <%= link_to shop_path(shop) do %>
       <div class="shop-card">
         <% if shop.photo.present? %>
+          <p class="relative-jpic jpic jpic-<%= shop.category_icon %>"></p>
           <%= cl_image_tag shop.photo.key%>
         <% else %>
+          <p class="relative-jpic jpic jpic-<%= shop.category_icon %>"></p>
           <%= image_tag 'https://www.jldb.bunka.go.jp/assets/images/202203/x/4085dffb4fb4cdd759c95e998ff54227.jpg' %>
         <% end %>
         <div class="shop-content">
-          <h5><%= shop.name %></h5>
+          <h6><%= shop.name %></h6>
           <p><%= shop.address.split(",").first %></p>
         </div>
       </div>
@@ -16,8 +18,6 @@
   <% end %>
 </div>
 
-
 <%# COMPONENTS USED IN THIS VIEW:
   _shop_card.scss
-
- %>
+%>

--- a/app/views/stamp_rallies/_shop_participants.erb
+++ b/app/views/stamp_rallies/_shop_participants.erb
@@ -2,13 +2,15 @@
   <% @stamp_rally.shop_participants.each do |shop_participant| %>
     <div class="shop-card-rally">
       <% if shop_participant.shop.photo.attached? %>
-        <%= cl_image_tag shop_participant.shop.photo.key, class: "shop-img" %>
+        <p class="relative-jpic jpic jpic-<%= shop_participant.shop.category_icon %>"></p>
+        <%= cl_image_tag shop_participant.shop.photo.key %>
       <% else %>
+        <p class="relative-jpic jpic jpic-<%= shop_participant.shop.category_icon %>"></p>
         <%= image_tag 'https://images.unsplash.com/photo-1612014449419-ac12de2f2181?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80', class: "shop-img" %>
       <% end %>
 
       <div class="shop-content">
-        <h5><%= link_to shop_participant.shop.name, shop_path(shop_participant.shop) %></h5>
+        <h6><%= link_to shop_participant.shop.name, shop_path(shop_participant.shop) %></h6>
 
         <%# QR code button %>
         <% if user_signed_in? %>
@@ -28,5 +30,5 @@
 <%# COMPONENTS USED IN THIS VIEW:
   _card_shop.scss
   _modal.scss
-  
- %>
+  the code for icons on top of images is in _card_shop.scss
+%>


### PR DESCRIPTION
Changes: 
- Changed the grid that contains the shop cards to two columns on phone screens. It changes to one column when smaller than 350px. (Changes applied to shops index and stamp rally show pages)
- Added a hover effect to shop cards and they increase in size a little
- Added the icons for each shop 

<img width="505" alt="Captura de Pantalla 2023-02-25 a las 17 51 30" src="https://user-images.githubusercontent.com/70474104/221348145-e43ebc4a-a748-493a-8f99-7f183e7179d0.png">
