### PR TITLE
Divide stamp rallies by status

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -17,6 +17,7 @@
 @import "rally_form";
 @import "banner";
 @import "dates";
+@import "tab";
 
 // Related to stamp cards
 @import "stamp_card";

--- a/app/assets/stylesheets/components/_tab.scss
+++ b/app/assets/stylesheets/components/_tab.scss
@@ -1,0 +1,19 @@
+.tabs-underlined {
+  display: flex;
+  align-items: center;
+}
+
+.tabs-underlined .tab-underlined {
+  color: black;
+  padding: 8px;
+  margin: 8px;
+  opacity: .4;
+  cursor: pointer;
+  text-decoration: none;
+  border-bottom: 4px solid transparent;
+}
+
+.tabs-underlined .tab-underlined.active {
+  opacity: 1;
+  border-bottom: 3px solid #555555;
+}

--- a/app/controllers/stamp_rallies_controller.rb
+++ b/app/controllers/stamp_rallies_controller.rb
@@ -10,7 +10,7 @@ class StampRalliesController < ApplicationController
     if params[:query].present? # code for searchbar
       @stamp_rallies = StampRally.search_by_name_and_description(params[:query])
     else
-      @stamp_rallies = StampRally.all
+      @stamp_rallies = StampRally.all.order("start_date ASC")
     end
 
     # Only display the ongoing stamp_rallies

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,6 +13,9 @@ application.register("map", MapController)
 import QrScannerController from "./qr_scanner_controller"
 application.register("qr-scanner", QrScannerController)
 
+import RalliesTabController from "./rallies_tab_controller"
+application.register("rallies-tab", RalliesTabController)
+
 import RallyMapController from "./rally_map_controller"
 application.register("rally-map", RallyMapController)
 

--- a/app/javascript/controllers/rallies_tab_controller.js
+++ b/app/javascript/controllers/rallies_tab_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="rallies-tab"
+export default class extends Controller {
+
+  static targets = ["rallies", "link"]
+
+  connect() {
+    console.log("Connected")
+  }
+
+}

--- a/app/views/stamp_rallies/index.html.erb
+++ b/app/views/stamp_rallies/index.html.erb
@@ -3,18 +3,18 @@
     <div class="padding" data-controller="rallies-tab">
       <h1 class="mb-3">Our popular Stamp Rallies</h1>
       <%= render "stamp_rallies/searchbar" %>
-      <ul class="list-inline tabs-underlined mt-3 mb-4">
-        <%= link_to "#" do %>
-          <li class="tab-underlined active"
+      <%# <ul class="list-inline tabs-underlined mt-3 mb-4"> %>
+        <%# link_to "#" do %>
+          <%# <li class="tab-underlined active"
           data-action="click->rallies-tab#greeting"
-          data-rallies-tab-target="link">Ongoing</li>
-        <% end %>
-        <%= link_to "#" do %>
-          <li class="tab-underlined"
+          data-rallies-tab-target="link">Ongoing</li> %>
+        <%# <% end %>
+        <%# link_to "#" do %>
+          <%# <li class="tab-underlined"
           data-action="click->rallies-tab#greeting"
-          data-rallies-tab-target="link">Coming soon</li>
-        <% end %>
-      </ul>
+          data-rallies-tab-target="link">Coming soon</li> %>
+        <%# end %>
+      <%# </ul> %>
       <%= render "rallies", stamp_rallies: @stamp_rallies, "data-rallies-tab-target":"rallies" %>
     </div>
   </div>

--- a/app/views/stamp_rallies/index.html.erb
+++ b/app/views/stamp_rallies/index.html.erb
@@ -1,9 +1,21 @@
 <div class="view-container">
   <div class="scroll-content container">
-    <div class="padding">
+    <div class="padding" data-controller="rallies-tab">
       <h1 class="mb-3">Our popular Stamp Rallies</h1>
       <%= render "stamp_rallies/searchbar" %>
-      <%= render "rallies", stamp_rallies: @stamp_rallies %>
+      <ul class="list-inline tabs-underlined mt-3 mb-4">
+        <%= link_to "#" do %>
+          <li class="tab-underlined active"
+          data-action="click->rallies-tab#greeting"
+          data-rallies-tab-target="link">Ongoing</li>
+        <% end %>
+        <%= link_to "#" do %>
+          <li class="tab-underlined"
+          data-action="click->rallies-tab#greeting"
+          data-rallies-tab-target="link">Coming soon</li>
+        <% end %>
+      </ul>
+      <%= render "rallies", stamp_rallies: @stamp_rallies, "data-rallies-tab-target":"rallies" %>
     </div>
   </div>
 


### PR DESCRIPTION
Changes: 
- Ordered the stamp rallies by start date, so now the coming soon ones appear at the bottom of the list
- My next step is to make a tab with two buttons so that users can check the current and the coming soon stamp rallies (I added the stimulus controller but it's not working yet)

<img width="709" alt="Captura de Pantalla 2023-02-28 a las 14 20 13" src="https://user-images.githubusercontent.com/70474104/221761165-3c77b45d-8756-4acd-8569-a2b6fb18852c.png">
