### PR TITLE
add tabs to rallies

### DIFF
--- a/app/controllers/stamp_rallies_controller.rb
+++ b/app/controllers/stamp_rallies_controller.rb
@@ -13,6 +13,13 @@ class StampRalliesController < ApplicationController
       @stamp_rallies = StampRally.all.order("start_date ASC")
     end
 
+    #
+    if params[:coming_soon].present?
+      @stamp_rallies = StampRally.where("start_date > CURRENT_DATE")
+    elsif params[:ongoing].present?
+      @stamp_rallies = StampRally.where("CURRENT_DATE BETWEEN start_date AND end_date")
+    end
+    
     # Only display the ongoing stamp_rallies
     @markers = @stamp_rallies.geocoded.map do |rally|
       {

--- a/app/javascript/controllers/rallies_tab_controller.js
+++ b/app/javascript/controllers/rallies_tab_controller.js
@@ -3,10 +3,49 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="rallies-tab"
 export default class extends Controller {
 
-  static targets = ["rallies", "link"]
+  static targets = ["rallies", "allRallies", "ongoingRallies", "comingSoonRallies"]
 
-  connect() {
-    console.log("Connected")
+  // connect() {
+  //   console.log("Connected")
+  // }
+
+  hideAllRallies() {
+    console.log(this.ralliesTargets[0].children.children)
+  }
+
+  // to get the clicked tab
+  switchTab(event) {
+    event.preventDefault()
+
+    const target = event.target.getAttribute("data-rallies-tab-target")
+    let filter = ""
+    if (target === "comingSoonRallies") {
+      filter = "coming_soon=1"
+    } else if (target === "ongoingRallies") {
+      filter = "ongoing=1"
+    }
+    const url = `/stamp_rallies?${filter}`
+    window.location.href = url
+    // fetch(url, { headers: { "X-Requested-With": "XMLHttpRequest" } })
+    //   .then(response => console.log(response.text()))
+
+      // .then(html => {
+      //   const container = this.ralliesTargets.querySelector(`[data-rallies-tab-target="${target}"]`)
+      //   console.log(html)
+      //   // container.innerHTML = html
+      // })
+  }
+
+  showAll() {
+    this.hideAllRallies()
+  }
+
+  showOngoingRallies() {
+    console.log(this.ongoingRalliesTarget)
+  }
+
+  showComingSoonRallies() {
+    console.log(this.comingSoonRalliesTarget)
   }
 
 }

--- a/app/views/stamp_rallies/index.html.erb
+++ b/app/views/stamp_rallies/index.html.erb
@@ -3,19 +3,73 @@
     <div class="padding" data-controller="rallies-tab">
       <h1 class="mb-3">Our popular Stamp Rallies</h1>
       <%= render "stamp_rallies/searchbar" %>
-      <%# <ul class="list-inline tabs-underlined mt-3 mb-4"> %>
+
+      <ul class="list-inline tabs-underlined mt-3 mb-4">
         <%# link_to "#" do %>
-          <%# <li class="tab-underlined active"
-          data-action="click->rallies-tab#greeting"
-          data-rallies-tab-target="link">Ongoing</li> %>
-        <%# <% end %>
-        <%# link_to "#" do %>
-          <%# <li class="tab-underlined"
-          data-action="click->rallies-tab#greeting"
-          data-rallies-tab-target="link">Coming soon</li> %>
+          <li class="tab-underlined active" id="all"
+          <%# data-action="click->rallies-tab#showAll" %>
+          data-action="click->rallies-tab#switchTab"
+          data-rallies-tab-target="allRallies">All</li>
         <%# end %>
-      <%# </ul> %>
-      <%= render "rallies", stamp_rallies: @stamp_rallies, "data-rallies-tab-target":"rallies" %>
+        <%# link_to "#" do %>
+          <li class="tab-underlined" id="ongoing"
+          <%# data-action="click->rallies-tab#showOngoingRallies" %>
+          data-action="click->rallies-tab#switchTab"
+          data-rallies-tab-target="ongoingRallies">Ongoing</li>
+        <%# end %>
+        <%# link_to "#" do %>
+          <li class="tab-underlined" id="soon"
+          <%# data-action="click->rallies-tab#showComingSoonRallies" %>
+          data-action="click->rallies-tab#switchTab"
+          data-rallies-tab-target="comingSoonRallies">Coming soon</li>
+        <%# end %>
+      </ul>
+
+    <%# rallies %>
+    <div class="mt-3" data-rallies-tab-target="rallies">
+      <% @stamp_rallies.each do |rally| %>
+        <%# <% unless rally.end_date.past? %>
+        <% if (current_user != nil && current_user.status == 0) || !rally.end_date.past? %>
+          <%= link_to stamp_rally_path(rally) do %>
+            <div class="rally-card <%= if rally.end_date.past?
+                "finished"
+              elsif Date.today.between?(rally.start_date, rally.end_date)
+                "ongoing"
+              else
+                "soon"
+              end %>">
+              <div>
+                <h6 class="rally-title"><%= rally.name %></h6>
+                <div class="dates">
+                  <p><%= rally.start_date %></p> -
+                  <p><%= rally.end_date %></p>
+                </div>
+              </div>
+              <div class="flex">
+                <p class="tag"><%= pluralize(rally.shop_participants.count, "shop") %></p>
+                <% if rally.end_date.past? %>
+                  <p class="tag">Finished</p>
+                <% elsif Date.today.between?(rally.start_date, rally.end_date) %>
+                  <p class="tag">Ongoing</p>
+                <% else %>
+                  <p class="tag">Coming soon</p>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+
+
+<%# COMPONENTS USED IN THIS VIEW:
+  _card_stamp_rally.scss
+  _tag
+  _dates
+%>
+
+
+      <%# render "rallies", stamp_rallies: @stamp_rallies, "data-rallies-tab-target":"rallies" %>
     </div>
   </div>
 


### PR DESCRIPTION
Changes: 
- Added tabs in the show page to filter ongoing and coming soon rallies (no ajax yet, but it works!)

<img width="665" alt="Captura de Pantalla 2023-02-28 a las 22 19 50" src="https://user-images.githubusercontent.com/70474104/221868274-9ee1edbd-c234-43d7-bf07-644d7c17e859.png">
