### PR TITLE
Style for stamp rallies cards in user dashboard

### DIFF
--- a/app/assets/stylesheets/components/_card_stamp_rally.scss
+++ b/app/assets/stylesheets/components/_card_stamp_rally.scss
@@ -82,6 +82,16 @@
   }
 }
 
+// flex for user dashboard rallies cards:
+.flex.user-dashboard {
+  @media(max-width: 576px) {
+    flex-direction: column;
+    .icons-container {
+      margin-top: 10px;
+    }
+  }
+}
+
 .background-section {
   border-top-left-radius: 5px;
   border-bottom-left-radius: 5px;
@@ -96,7 +106,7 @@
 
 .links {
   display: flex;
-  margin-top: 10px;
+  margin-top: 5px;
   align-items: flex-end;
 }
 

--- a/app/views/pages/_user_dash.html.erb
+++ b/app/views/pages/_user_dash.html.erb
@@ -28,21 +28,27 @@
           <% @shop_participants = @stamp_rally.shop_participants %>
           <% @stamp_card = StampCard.where(participant: participant, stamp_rally: @stamp_rally).first %>
             <div class="rally-card ongoing">
-              <div>
+              <div class="background-section">
                 <h6><%= link_to @stamp_rally.name, stamp_rally_path(@stamp_rally), class: "rally-title" %></h6>
+                <% shops_status = @stamp_card.shops_status %>
+                <p class="mb-0"><%= shops_status.select {|k, v| v == "stamped"}.length %> / <%= pluralize(@stamp_rally.shop_participants.count, "stamp") %> collected</p>
               </div>
-              <div>
-               <% shops_status = @stamp_card.shops_status %>
-                 <p class="mb-0"><%= shops_status.select {|k, v| v == "stamped"}.length %> / <%= pluralize(@stamp_rally.shop_participants.count, "stamp") %> collected</p>
+              <div class="flex user-dashboard">
                 <div class="links">
                   <%= link_to stamp_rally_participant_stamp_card_path(@stamp_rally, participant, @stamp_card), class: "small-button" do %>
-                     <%= image_tag('icon-stamp.png') %> Stamps
+                    <%= image_tag('icon-stamp.png') %> Stamps
                   <% end %>
                   <%= link_to map_view_stamp_rally_participant_stamp_card_path(@stamp_rally, participant, @stamp_card), class: "small-button" do %>
                     <i class="fa fa-solid fa fa-map me-2"></i> Map
                   <% end %>
                   <% if @stamp_card.status == "completed" %>
                     <p class="complete-sign">Completed!</p>
+                  <% end %>
+                </div>
+                <div class="icons-container">
+                  <% icons = @stamp_rally.shop_participants.map { |shop_participant| shop_participant.shop.category_icon }.uniq.first(5) %>
+                  <% icons.each do |icon| %>
+                    <p class="jpic jpic-<%= icon %>"></p>
                   <% end %>
                 </div>
               </div>


### PR DESCRIPTION
Changes: 
- Changed the structure of the stamp rally cards on the user-dashboard, now they look the same as the rest

<img width="973" alt="Captura de Pantalla 2023-03-03 a las 17 53 06" src="https://user-images.githubusercontent.com/70474104/222675870-9765b2ea-2227-4fd2-988d-8fcbfe069ede.png">
