### PR TITLE
Fixed? the map height on mobile view

### DIFF
--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -59,7 +59,7 @@
   height: 89.5vh;
   width: 900px;
   @media(max-width: 992px) {
-    height: 350px;
+    // height: 350px;
     width: 100%;
     box-shadow: 0 0 15px rgba(0,0,0,0.2);
   }


### PR DESCRIPTION
Changes: 
- I deleted the fixed height on the rally-maps and now it should look bigger


<img width="306" alt="Captura de Pantalla 2023-03-04 a las 17 54 38" src="https://user-images.githubusercontent.com/70474104/222886688-2cb0a6c7-4653-481d-81a7-51ae8647cdba.png">
