### PR TITLE
Add go back button to rallies show page and shops show page

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -16,6 +16,24 @@
   }
 }
 
+.back-btn {
+  height: 50px;
+  width: 50px;
+  padding: 10px;
+  border-radius: 50%;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  i {
+    font-size: 22px;
+    font-weight: bold;
+  }
+  &:active {
+    position: relative;
+    top: 2px;
+  }
+}
 
 .button {
   background: $blue;

--- a/app/assets/stylesheets/components/_owner_profile.scss
+++ b/app/assets/stylesheets/components/_owner_profile.scss
@@ -1,5 +1,5 @@
 .owner-profile {
-  margin: 20px 10px;
+  margin: 20px 0px;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/app/views/pages/_user_dash.html.erb
+++ b/app/views/pages/_user_dash.html.erb
@@ -58,7 +58,7 @@
           <% end %>
         <% else %>
           <p>You are not participating in any stamp rallies at the moment...</p>
-          <p><%= link_to "Look for stamp rallies in your area!", stamp_rallies_path, class: "btn btn-primary" %></p>
+          <p><%= link_to "Look for stamp rallies in your area!", stamp_rallies_path, class: "btn btn-primary mt-3" %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,10 +1,10 @@
-<div class="container py-5">
-  <% if user_signed_in? && current_user.status == "chairperson" %>
-    <%= link_to shops_path do %>
-      <p class="mb-3"><i class="fa-solid fa-chevron-left me-2"></i>Back to <%= current_user.street_name %></p>
-    <% end %>
+<div class="container py-3">
+  <%= link_to :back, class:"mb-3" do %>
+    <div class="mb-3 back-btn">
+      <i class="fa fa-solid fa fa-chevron-left"></i>
+    </div>
   <% end %>
-  <%= render 'shops/shop_info' %> <br>
 
+  <%= render 'shops/shop_info' %> <br>
   <%= render 'shops/shopowner_profile' %>
 </div>

--- a/app/views/stamp_rallies/show.html.erb
+++ b/app/views/stamp_rallies/show.html.erb
@@ -8,7 +8,13 @@
 </div>
 
 <%# container for rally description %>
-<div class="container my-5">
+<div class="container my-3">
+  <%= link_to :back, class:"mb-3" do %>
+    <div class="mb-3 back-btn">
+      <i class="fa fa-solid fa fa-chevron-left"></i>
+    </div>
+  <% end %>
+
   <div class="about-container">
     <div class="rally-info p-3">
       <div>


### PR DESCRIPTION
Changes: 
- On mobile view when we go to a shop show page, there is no way to go back, so I added a go back button. I changed the style of the "go back" button that we already had on rallies show page.

<img width="742" alt="Captura de Pantalla 2023-03-09 a las 11 23 10" src="https://user-images.githubusercontent.com/70474104/223899610-b8aa8f3b-7368-4eb3-a8ac-9c44d9c26560.png">

<img width="702" alt="Captura de Pantalla 2023-03-09 a las 11 23 03" src="https://user-images.githubusercontent.com/70474104/223899617-092b1915-fcc7-452c-aba7-99f87343831b.png">
